### PR TITLE
fix: Malmö calendar showing Lund events due to Unicode word boundary bug

### DIFF
--- a/app/api/calendar/[city]/route.ts
+++ b/app/api/calendar/[city]/route.ts
@@ -10,7 +10,10 @@ export const revalidate = 86400
 export async function GET(request: Request, { params }: { params: Promise<{ city: string }> }) {
   try {
     const { city } = await params
-    console.log(`[Calendar API] Request for city: "${city}"`)
+    const url = new URL(request.url)
+    const includeSuburbs = url.searchParams.get("suburbs") !== "0"
+
+    console.log(`[Calendar API] Request for city: "${city}", suburbs: ${includeSuburbs}`)
     const decodedCity = decodeURIComponent(city)
     console.log(`[Calendar API] Decoded city: "${decodedCity}"`)
     // Normalize city slug to ASCII-safe characters (å→a, ä→a, ö→o)
@@ -40,7 +43,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ city
     const icsContent = await response.text()
 
     const { events } = parseICS(icsContent)
-    const filteredEvents = filterEventsByCity(events, decodedCity)
+    const filteredEvents = filterEventsByCity(events, decodedCity, includeSuburbs)
 
     if (filteredEvents.length === 0) {
       console.warn(`[Calendar API] No events found for city: ${decodedCity}`)

--- a/app/api/cities/route.ts
+++ b/app/api/cities/route.ts
@@ -4,9 +4,13 @@ import { parseICS, filterEventsByCity } from "@/lib/ics-parser"
 const ICS_FEED_URL = "https://klimatkalendern.nu/feed/instance/ics"
 
 export const revalidate = 86400 // Cache for 24 hours
+export const dynamic = "force-dynamic"
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const url = new URL(request.url)
+    const includeSuburbs = url.searchParams.get("suburbs") !== "0"
+
     const response = await fetch(ICS_FEED_URL, {
       cache: "no-store", // Don't cache fetch - let route-level revalidate handle caching
     })
@@ -21,7 +25,7 @@ export async function GET() {
     // Build array with city name and event count
     const citiesWithCounts = mentionedCities
       .map((city) => {
-        const filtered = filterEventsByCity(events, city)
+        const filtered = filterEventsByCity(events, city, includeSuburbs)
         return {
           name: city,
           count: filtered.length,

--- a/app/api/events/[city]/route.ts
+++ b/app/api/events/[city]/route.ts
@@ -8,6 +8,8 @@ export const revalidate = 86400 // Cache for 24 hours
 export async function GET(request: Request, { params }: { params: Promise<{ city: string }> }) {
   try {
     const { city } = await params
+    const url = new URL(request.url)
+    const includeSuburbs = url.searchParams.get("suburbs") !== "0"
 
     const response = await fetch(ICS_FEED_URL, {
       cache: "no-store", // Don't cache fetch - let route-level revalidate handle caching
@@ -19,7 +21,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ city
 
     const icsContent = await response.text()
     const { events } = parseICS(icsContent)
-    const filteredEvents = filterEventsByCity(events, decodeURIComponent(city))
+    const filteredEvents = filterEventsByCity(events, decodeURIComponent(city), includeSuburbs)
 
     return NextResponse.json({
       city: decodeURIComponent(city),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ export default function Home() {
   const [citiesLoading, setCitiesLoading] = useState(true)
   const [copied, setCopied] = useState(false)
   const [includeSuburbs, setIncludeSuburbs] = useState(true)
+  const [showSuburbList, setShowSuburbList] = useState(false)
   const hasMounted = useRef(false)
 
   useEffect(() => {
@@ -133,21 +134,38 @@ export default function Home() {
                   ))}
                 </SelectContent>
               </Select>
-              <p className="text-xs text-muted-foreground">{cities.length} kommuner har klimathändelser</p>
-              <label className="flex items-center gap-2 cursor-pointer select-none">
-                <input
-                  type="checkbox"
-                  checked={includeSuburbs}
-                  onChange={(e) => setIncludeSuburbs(e.target.checked)}
-                  className="h-4 w-4 rounded border-input accent-primary"
-                />
-                <span className="text-sm">Inkludera kranskommuner</span>
-                {selectedCity && getCityAliases(selectedCity).length > 0 && (
-                  <span className="text-xs text-muted-foreground">
-                    ({getCityAliases(selectedCity).join(", ")})
-                  </span>
-                )}
-              </label>
+              {selectedCity && getCityAliases(selectedCity).length > 0 && (
+                <div className="space-y-1.5">
+                  <label className="flex items-center gap-3 cursor-pointer select-none">
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={includeSuburbs}
+                      onClick={() => setIncludeSuburbs(!includeSuburbs)}
+                      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent transition-colors ${includeSuburbs ? "bg-primary" : "bg-muted-foreground/30"}`}
+                    >
+                      <span
+                        className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm transition-transform ${includeSuburbs ? "translate-x-4" : "translate-x-0"}`}
+                      />
+                    </button>
+                    <span className="text-sm">
+                      Inkluderar {getCityAliases(selectedCity).length}{" "}
+                      <button
+                        type="button"
+                        onClick={() => setShowSuburbList(!showSuburbList)}
+                        className="text-primary hover:underline"
+                      >
+                        kranskommuner
+                      </button>
+                    </span>
+                  </label>
+                  {showSuburbList && (
+                    <p className="text-xs text-muted-foreground pl-12">
+                      {getCityAliases(selectedCity).join(", ")}
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
 
             {/* Event Count */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -115,56 +115,67 @@ export default function Home() {
             <CardDescription>Välj en kommun för att se klimathändelser i ditt område</CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            {/* City Selector */}
-            <div className="space-y-2">
-              <Select value={selectedCity} onValueChange={setSelectedCity} disabled={citiesLoading}>
-                <SelectTrigger id="city-select" className="w-full">
-                  <SelectValue placeholder={citiesLoading ? "Laddar kommuner..." : "Välj kommun"} />
-                </SelectTrigger>
-                <SelectContent>
-                  {cities.map((cityData) => (
-                    <SelectItem key={cityData.name} value={cityData.name}>
-                      <div className="flex items-center justify-between w-full gap-3">
-                        <span>{cityData.name}</span>
-                        <span className="text-xs text-muted-foreground tabular-nums">
-                          {cityData.count} {cityData.count === 1 ? "händelse" : "händelser"}
-                        </span>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            {/* City Selector - iOS Settings-style grouped list */}
+            <div className="rounded-lg border overflow-hidden">
+              {/* Row 1: City dropdown */}
+              <div className="px-4 py-3">
+                <Select value={selectedCity} onValueChange={setSelectedCity} disabled={citiesLoading}>
+                  <SelectTrigger id="city-select" className="w-full" aria-label="Välj kommun">
+                    <SelectValue placeholder={citiesLoading ? "Laddar kommuner..." : "Välj kommun"} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {cities.map((cityData) => (
+                      <SelectItem key={cityData.name} value={cityData.name}>
+                        <div className="flex items-center justify-between w-full gap-3">
+                          <span>{cityData.name}</span>
+                          <span className="text-xs text-muted-foreground tabular-nums">
+                            {cityData.count} {cityData.count === 1 ? "händelse" : "händelser"}
+                          </span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Row 2: Suburbs toggle (only for cities with suburbs) */}
               {selectedCity && getCityAliases(selectedCity).length > 0 && (
-                <div className="space-y-1.5">
-                  <label className="flex items-center gap-3 cursor-pointer select-none">
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={includeSuburbs}
-                      onClick={() => setIncludeSuburbs(!includeSuburbs)}
-                      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent transition-colors ${includeSuburbs ? "bg-primary" : "bg-muted-foreground/30"}`}
-                    >
-                      <span
-                        className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm transition-transform ${includeSuburbs ? "translate-x-4" : "translate-x-0"}`}
-                      />
-                    </button>
-                    <span className="text-sm">
-                      Inkluderar {getCityAliases(selectedCity).length}{" "}
+                <>
+                  <div className="border-t" />
+                  <div className="px-4 py-3 space-y-1.5">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm">
+                        Inkludera {getCityAliases(selectedCity).length}{" "}
+                        <button
+                          type="button"
+                          onClick={() => setShowSuburbList(!showSuburbList)}
+                          className="text-primary underline underline-offset-2"
+                          aria-expanded={showSuburbList}
+                          aria-controls="suburb-list"
+                        >
+                          kranskommuner
+                        </button>
+                      </span>
                       <button
                         type="button"
-                        onClick={() => setShowSuburbList(!showSuburbList)}
-                        className="text-primary hover:underline"
+                        role="switch"
+                        aria-checked={includeSuburbs}
+                        aria-label={`Inkludera kranskommuner för ${selectedCity}`}
+                        onClick={() => setIncludeSuburbs(!includeSuburbs)}
+                        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${includeSuburbs ? "bg-primary" : "bg-muted-foreground/30"}`}
                       >
-                        kranskommuner
+                        <span
+                          className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm transition-transform ${includeSuburbs ? "translate-x-4" : "translate-x-0"}`}
+                        />
                       </button>
-                    </span>
-                  </label>
-                  {showSuburbList && (
-                    <p className="text-xs text-muted-foreground pl-12">
-                      {getCityAliases(selectedCity).join(", ")}
-                    </p>
-                  )}
-                </div>
+                    </div>
+                    {showSuburbList && (
+                      <p id="suburb-list" className="text-xs text-muted-foreground">
+                        {getCityAliases(selectedCity).join(", ")}
+                      </p>
+                    )}
+                  </div>
+                </>
               )}
             </div>
 
@@ -193,7 +204,7 @@ export default function Home() {
                       className="font-mono text-sm"
                       onClick={(e) => e.currentTarget.select()}
                     />
-                    <Button onClick={handleCopy} variant="outline" size="icon" className="shrink-0 bg-transparent">
+                    <Button onClick={handleCopy} variant="outline" size="icon" className="shrink-0 bg-transparent" aria-label={copied ? "Kopierad" : "Kopiera kalender-URL"}>
                       {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
                     </Button>
                   </div>
@@ -217,7 +228,7 @@ export default function Home() {
                             href="https://calendar.google.com"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-primary hover:underline"
+                            className="text-primary underline underline-offset-2"
                           >
                             Google Calendar
                           </a>{" "}
@@ -282,7 +293,7 @@ export default function Home() {
                             href="https://outlook.live.com/calendar"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-primary hover:underline"
+                            className="text-primary underline underline-offset-2"
                           >
                             Outlook Calendar
                           </a>
@@ -319,7 +330,7 @@ export default function Home() {
               href="https://klimatkalendern.nu"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary hover:underline"
+              className="text-primary underline underline-offset-2"
             >
               klimatkalendern.nu
             </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,25 +118,23 @@ export default function Home() {
             {/* City Selector - iOS Settings-style grouped list */}
             <div className="rounded-lg border overflow-hidden">
               {/* Row 1: City dropdown */}
-              <div className="px-4 py-3">
-                <Select value={selectedCity} onValueChange={setSelectedCity} disabled={citiesLoading}>
-                  <SelectTrigger id="city-select" className="w-full" aria-label="Välj kommun">
-                    <SelectValue placeholder={citiesLoading ? "Laddar kommuner..." : "Välj kommun"} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {cities.map((cityData) => (
-                      <SelectItem key={cityData.name} value={cityData.name}>
-                        <div className="flex items-center justify-between w-full gap-3">
-                          <span>{cityData.name}</span>
-                          <span className="text-xs text-muted-foreground tabular-nums">
-                            {cityData.count} {cityData.count === 1 ? "händelse" : "händelser"}
-                          </span>
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+              <Select value={selectedCity} onValueChange={setSelectedCity} disabled={citiesLoading}>
+                <SelectTrigger id="city-select" className="w-full border-0 shadow-none rounded-none px-4 py-3 h-auto" aria-label="Välj kommun">
+                  <SelectValue placeholder={citiesLoading ? "Laddar kommuner..." : "Välj kommun"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {cities.map((cityData) => (
+                    <SelectItem key={cityData.name} value={cityData.name}>
+                      <div className="flex items-center justify-between w-full gap-3">
+                        <span>{cityData.name}</span>
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          {cityData.count} {cityData.count === 1 ? "händelse" : "händelser"}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
 
               {/* Row 2: Suburbs toggle (only for cities with suburbs) */}
               {selectedCity && getCityAliases(selectedCity).length > 0 && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-v0-project",
+  "name": "climate-city-calendar",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-v0-project",
+      "name": "climate-city-calendar",
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Problem

En användare rapporterade att Malmö-kalendern enbart visade Lund-händelser (21 st, identiska med Lund-kalendern). Inga faktiska Malmö-händelser dök upp.

### Rotorsak: JavaScript `\b` och svenska tecken

JavaScripts `\b` regex word boundary behandlar å, ä, ö som **icke-ord-tecken** (bara `[a-zA-Z0-9_]` räknas). Det innebär att `\bMalmö\b` **aldrig matchar** texten "Malmö" eftersom ö→mellanslag är non-word→non-word = ingen word boundary.

Malmö-kalendern returnerade enbart Lund-händelser och "Lund" (bara ASCII) matchade korrekt, medan "Malmö" aldrig gjorde det.

Buggen påverkade alla städer som börjar/slutar med å/ä/ö: Malmö, Luleå, Umeå, Örebro, Östersund, Ängelholm, Åre m.fl.

### Sekundärt: Lund som Malmö-alias

Lund (pop. ~130k, 18 km från Malmö) var felaktigt listad som Malmö-förort i `CITY_ALIASES`.

## Fix

- **Normalisera till ASCII före regex-matchning**: Både söktext och stadsnamn konverteras via `normalizeSwedish()` (å→a, ä→a, ö→o) innan `\b` word boundaries appliceras
- **Ta bort Lund från Malmö-alias**: Lund är en självständig stad
- **"Inkludera kranskommuner"-toggle**: Användare kan slå av/på inkludering av kranskommuner (default: på)
- **iOS Settings-stil UI**: Dropdown och toggle i grupperat kort med divider
- **Tillgänglighetsförbättringar**: Permanenta understrykningar på länkar, aria-labels, focus-visible rings

## Testat

- [x] Malmö-kalender returnerar Malmö-event (inte Lund)
- [x] Lund-kalender returnerar enbart Lund-händelser ("annorlunda" matchar inte "lund")
- [x] Kranskommuner-toggle fungerar
- [x] Build passerar